### PR TITLE
Correct unsemantic text and inconsistent list indentations and line breaks in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Steam-Leaderboard-Moderation
-```Version 1.1```
+
+`Version 1.1`
 
 A web application written in Node.js interfacing with the Steam API, allowing for easy removal and editing of leaderboard entries since Steam itself lacks this feature.
 
@@ -15,46 +16,50 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
 
 ### Installation
 
-1. Clone the repository:
+1.  Clone the repository:
+
     ```sh
     git clone https://github.com/Stefaaan06/Steam-Leaderboard-Moderation.git
     cd Steam-Leaderboard-Moderation
     ```
 
-2. Install dependencies:
+3.  Install dependencies:
+
     ```sh
     npm install
     ```
 
-3. Create a `.env` file in the root directory and add your Steam Publisher API Key:
+4.  Create a `.env` file in the root directory and add your Steam Publisher API Key:
+
     ```env
     STEAM_PUBLISHER_API_KEY=your_api_key_here
     ```
-   How to get your API key: https://partner.steamgames.com/doc/webapi_overview/auth
 
+   How to get your API key: visit https://partner.steamgames.com/doc/webapi_overview/auth.
 
-4. (optional) Update index.html with your own appID -
-   The appID in index.html is currently configured for my own game. Replace it with your own appID. You can also add multiple options
+5.  (Optionally) Update `index.html` with your own `appID`:
+
+    The `appID` in `index.html` is currently configured for my own game. Replace it with your own `appID`. You can also add multiple options:
+   
     ```html
     <select id="appidSelect">
         <option value="YOUR APP ID">YOUR APP NAME</option>
     </select>
     ```
-   You can also input an appID when selecting "Custom" in the dropdown.
 
-5. Start the server:
+    You can also input an appID when selecting "Custom" in the dropdown.
+
+6.  Start the server:
+
     ```sh
     npm start
     ```
-      
 
-6. The website will run on `http://localhost:3000`.
+7.  The website will run on `http://localhost:3000`.
 
-
-7. You can also optionally run this on an actual server with an actual run configuration.
+8.  You can also optionally run this on an actual server with an actual run configuration.
 
 ## Usage Guide
-
 
 ### Viewing Leaderboards
 
@@ -73,11 +78,16 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
 
 1. Click the "Remove" button next to the entry you want to remove.
 2. Confirm the removal.
-3. **(this does not actually remove the entry but replaces it with a very large value)**
-   -> this only makes sense for ASCENDING score boards. **not for descending ones**. The removal value can be edited in moderation.js "const removalScore = 9999999999;"
+3. **(This does not actually remove the entry, but replaces it with a very large value.)**
+   
+   → This only makes sense for ASCENDING score boards. **Not for descending ones.** The removal value can be edited [in `moderation.js`](https://github.com/Stefaaan06/Steam-Leaderboard-Moderation/blob/6b40a6a38455a415c8668cbe22fe59a990f33fda/routes/moderation.js#L62) with:
 
+   ```js
+   const removalScore = 9999999999;
+   ```
 
 ### Known Issues
+
 1. When Removing / Editing entries the displayed entries on the website don´t update properly.
 2. No full support for Descending leaderboards yet
 3. The website stashes your changes in local storage on purpose. This is because steam leaderboards may take some time to update.
@@ -90,5 +100,4 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
 
 ## License & Contribution
 
-This project is licensed under the MIT License.
-Any contribution is welcome and will be under the same license.
+This project is licensed under the MIT License. Any contribution is welcome and will be under the same license.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
     cd Steam-Leaderboard-Moderation
     ```
 
-3.  Install dependencies:
+2.  Install dependencies:
 
     ```sh
     npm install
     ```
 
-4.  Create a `.env` file in the root directory and add your Steam Publisher API Key:
+3.  Create a `.env` file in the root directory and add your Steam Publisher API Key:
 
     ```env
     STEAM_PUBLISHER_API_KEY=your_api_key_here
@@ -37,7 +37,7 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
 
    How to get your API key: visit https://partner.steamgames.com/doc/webapi_overview/auth.
 
-5.  (Optionally) Update `index.html` with your own `appID`:
+4.  (Optionally) Update `index.html` with your own `appID`:
 
     The `appID` in `index.html` is currently configured for my own game. Replace it with your own `appID`. You can also add multiple options:
    
@@ -49,15 +49,15 @@ A web application written in Node.js interfacing with the Steam API, allowing fo
 
     You can also input an appID when selecting "Custom" in the dropdown.
 
-6.  Start the server:
+5.  Start the server:
 
     ```sh
     npm start
     ```
 
-7.  The website will run on `http://localhost:3000`.
+6.  The website will run on `http://localhost:3000`.
 
-8.  You can also optionally run this on an actual server with an actual run configuration.
+7.  You can also optionally run this on an actual server with an actual run configuration.
 
 ## Usage Guide
 


### PR DESCRIPTION
1. Erroneously uncodified code is now semantic, for the sake of screen readers.

3. Some capital letters and periods were lacked. They've now been remediated.

This is all that should be visible outside of the source view. Otherwise, line breaks and indentations in lists are now consistent, which matters in CommonMark!